### PR TITLE
Fix https://github.com/webard/nova-suneditor/issues/5

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -97,7 +97,7 @@ export default {
         },
 
         fill(formData) {
-            this.fillIfVisible(formData, this.fieldAttribute, this.editor.getContents() || '')
+            this.fillIfVisible(formData, this.fieldAttribute, this.editor?.getContents() || '')
         },
 
         onSyncedField() {


### PR DESCRIPTION
Adds optional chaining to `this.editor.getContents()` to fix issue https://github.com/webard/nova-suneditor/issues/5 where hidden SunEditor fields will cause an error when attempting to save as the editor hasn't been initialised.