### PR TITLE
array type return

### DIFF
--- a/src/SunEditor.php
+++ b/src/SunEditor.php
@@ -115,7 +115,7 @@ class SunEditor extends Field implements DeletableContract, FilterableField, Sto
      *
      * @return array
      */
-    public function serializeForFilter()
+    public function serializeForFilter(): array
     {
         return transform($this->jsonSerialize(), function ($field) {
             return Arr::only($field, [


### PR DESCRIPTION
I'm using the sequin versions:
PHP 8.2.15 
Nova V5.0
Laravel 11.31

It was throwing an error:
![Captura de Tela 2025-01-26 às 19 35 29](https://github.com/user-attachments/assets/a7092e23-7855-4f08-b732-c3c94550343c)

It was necessary to adjust it to include the array type return

